### PR TITLE
feat: Improve config and portability

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,10 +4,10 @@ on:
   schedule:
     - cron: '19 4 * * *'
   push:
-    branches: [ main, '0.0.1' ]
+    branches: [ main, '0.0.1', '0.1.0' ]
 
 env:
-  LATEST: '0.0.1'
+  LATEST: '0.1.0'
   REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,17 +14,20 @@ RUN apt-get update \
  
 FROM python:3.10-slim AS release
 
-RUN groupadd -g 999 python && \
-    useradd -r -u 999 -g python python
+RUN groupadd -g 999 python \
+ && useradd -r -u 999 -g python python \
+ && mkdir app \
+ && chown python:python app
 USER 999
 
 WORKDIR /app
-COPY --from=build /app/venv ./venv
-COPY ./scripts/start-poetry.sh .
-COPY ./server ./server
-COPY ./pyproject*.toml ./
-COPY ./poetry*.lock ./
+COPY --chown=python:python --from=build /app/venv ./venv
+COPY --chown=python:python --from=build /app/poetry*.lock ./
+COPY --chown=python:python --from=build /app/pyproject*.toml ./
+COPY --chown=python:python ./scripts/start-poetry.sh .
+COPY --chown=python:python ./server ./server
 
 EXPOSE 3000
 
 CMD [ "./start-poetry.sh", "poetry", "run", "uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "3000" ]
+HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 CMD curl -f http://localhost:3000/health

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![](https://dockeri.co/image/netreconlab/ca-server)](https://hub.docker.com/r/netreconlab/ca-server)
 [![Docker](https://github.com/netreconlab/ca-server/actions/workflows/build.yml/badge.svg)](https://github.com/netreconlab/ca-server/actions/workflows/build.yml)
 [![Docker](https://github.com/netreconlab/ca-server/actions/workflows/release.yml/badge.svg)](https://github.com/netreconlab/ca-server/actions/workflows/release.yml)
+![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)
 
 ---
 Quickly create Certificate Authorities (CAs) for your applications.

--- a/README.md
+++ b/README.md
@@ -11,15 +11,51 @@ Multiple images are automatically built for your convenience. Images can be foun
 - [Docker - Hosted on Docker Hub](https://hub.docker.com/r/netreconlab/ca-server)
 - [Singularity - Hosted on GitHub Container Registry](https://github.com/netreconlab/hipaa-postgres/pkgs/container/ca-server)
 
+## Environment Variables
+Below is a list of environment variables available to configure `ca-server`. It is required to mount the folder containing `CA_SERVER_PRIVATE_KEY_FILE` and `CA_SERVER_ROOT_CA_CERT`. It is recommended to mount the folder containing `CA_SERVER_DATABASE_NAME` to persist your database during restarts. It is also recommended to mount the folder containing `CA_SERVER_CA_DIRECTORY` to persist any files created by `ca-server`.
+
+```bash
+CA_SERVER_PRIVATE_KEY_FILE=./server/ca/private/cakey.pem # (Required) Location and name of private key 
+CA_SERVER_ROOT_CA_CERT=./server/ca/private/cacert.der # (Required) Location and name of CA certificate
+CA_SERVER_DATABASE_NAME=./server/dbs/appdb.sqlite # (Required) Location and name of the database
+CA_SERVER_CA_DIRECTORY=./server/ca # Location to store CA related files
+CA_SERVER_ROUTE_USER_PREFIX=/appusers # The prefix to add to all user related routes
+CA_SERVER_ROUTE_CERTIFICATE_PREFIX=/certificates # The prefix to add to all certificate related routes
+CA_SERVER_ROUNDS=5 # Number of rounds
+```
+
 ## Local Deployment
 ### Option 1
 Use the docker-compose.yml file to run on a docker container or
-1. In terminal, run `docker-compose up`
-2. Then Go to `http://localhost:3000/docs` to view api docs and use as needed
+1. Fork this repo
+2. In terminal, run `docker-compose up`
+3. Then Go to `http://localhost:3000/docs` to view api docs and use as needed
 
 ### Option 2
 Run directly on your local machine by:
-1. Installing python 3.10.x and poetry
-2. Running `poetry install in the root directory`
-3. Run `poetry run uvicorn server.main:app --host 0.0.0.0 --port 3000`
-4. Then Go to `http://localhost:3000/docs` to view api docs and use as needed
+1. Fork this repo
+2. Install python 3.10.x and poetry
+3. Running `poetry install in the root directory`
+4. Run `poetry run uvicorn server.main:app --host 0.0.0.0 --port 3000`
+5. Then Go to `http://localhost:3000/docs` to view api docs and use as needed
+
+## Running behind a proxy
+If you need to run `ca-server` behind a proxy, `--root-path` needs to be added to command to start `ca-server` in the `docker-compose.yml` file. The root path should match the exact endpoint proxying to `ca-server`. For example, if your endpoint is `/ca`, then the proper command is below:
+
+```bash
+# `docker-compose.yml` 
+command: [ "./start-poetry.sh", "poetry", "run", "uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "3000", "--root-path", "/ca" ]
+```
+
+In addition, two endpoints to the nginx configuration file:
+```bash
+# Allow access to the docs of your ca-server
+location /ca/docs {
+    proxy_pass http://ca-server:3000/docs;
+}
+
+# Allow access to the rest of your ca-server api
+location /ca/ {
+    proxy_pass http://ca-server:3000/;
+}
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: "3"
 services:
-  ca-app:
+  ca-server:
     image: netreconlab/ca-server:latest
     environment:
       - CA_SERVER_PRIVATE_KEY_FILE=./server/ca/private/cakey.pem # (Required) Location and name of private key
@@ -10,6 +10,8 @@ services:
       - CA_SERVER_ROUTE_USER_PREFIX=/appusers # The prefix to add to all user related routes
       - CA_SERVER_ROUTE_CERTIFICATE_PREFIX=/certificates # The prefix to add to all certificate related routes
       - CA_SERVER_ROUNDS=5 # Number of rounds
+    # Uncomment the command below if you are running behind a proxy. Change "/ca" to your respective endpoint.
+    # command: [ "./start-poetry.sh", "poetry", "run", "uvicorn", "server.main:app", "--host", "0.0.0.0", "--port", "3000", "--root-path", "/ca" ]
     restart: always
     volumes:
       - ./server/ca:/app/server/ca

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,15 @@
 version: "3"
 services:
   ca-app:
-    build: .
+    image: netreconlab/ca-server:latest
     environment:
-      - DATABASE_NAME=server/dbs/appdb.sqlite
-      - RSA_PRIVATE_KEY=./server/ca/private/cakey.pem
-      - ROOT_CA_CERT=./server/ca/private/cacert.der
-      - ROUNDS=5
+      - CA_SERVER_PRIVATE_KEY_FILE=./server/ca/private/cakey.pem # (Required) Location and name of private key
+      - CA_SERVER_ROOT_CA_CERT=./server/ca/private/cacert.der # (Required) Location and name of CA certificate
+      - CA_SERVER_DATABASE_NAME=server/dbs/appdb.sqlite # (Required) Location and name of the database
+      - CA_SERVER_CA_DIRECTORY=./server/ca # Location to store CA related files
+      - CA_SERVER_ROUTE_USER_PREFIX=/appusers # The prefix to add to all user related routes
+      - CA_SERVER_ROUTE_CERTIFICATE_PREFIX=/certificates # The prefix to add to all certificate related routes
+      - CA_SERVER_ROUNDS=5 # Number of rounds
     restart: always
     volumes:
       - ./server/ca:/app/server/ca

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ in-project = true
 
 [tool.poetry]
 name = "ca-server"
-version = "0.0.1"
+version = "0.1.0"
 description = "Quickly create Certificate Authorities (CAs) for your applications."
 authors = ["shina-m <shina.ct@gmail.com>"]
 

--- a/server/cert.py
+++ b/server/cert.py
@@ -9,8 +9,8 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 import os
 
-RSA_PRIVATE_KEY = os.getenv('RSA_PRIVATE_KEY')
-ROOT_CA_CERT = os.getenv('ROOT_CA_CERT')
+RSA_PRIVATE_KEY = os.getenv('CA_SERVER_PRIVATE_KEY_FILE')
+ROOT_CA_CERT = os.getenv('CA_SERVER_ROOT_CA_CERT')
 
 class CA:
     def __init__(self):

--- a/server/crud.py
+++ b/server/crud.py
@@ -5,7 +5,8 @@ from server.cert import CA
 from cryptography.hazmat.primitives import serialization
 import os
 
-ROUNDS = os.getenv('ROUNDS')
+CA_DIRECTORY = os.getenv('CA_SERVER_CA_DIRECTORY', "./server/ca")
+ROUNDS = os.getenv('CA_SERVER_ROUNDS', 5)
 
 ca = CA()
 
@@ -52,8 +53,7 @@ def generate_cert(installationId: str, csr: str, validityIndays: int):
     signed_cert = ca.sign_certificate_request(csr_bytes=csr_b64bytes, validityIndays=validityIndays)
     # maybe create csr from string
     # convert signed_cert to string
-    ca_dir = "server/ca"
-    csr_dir = f"{ca_dir}/csrs/{installationId}.csr"
+    csr_dir = f"{CA_DIRECTORY}/csrs/{installationId}.csr"
     with open(csr_dir, "w") as text_file:
         text_file.write(csr)
 

--- a/server/database.py
+++ b/server/database.py
@@ -5,7 +5,7 @@ from contextvars import ContextVar
 import peewee
 import os
 
-DATABASE_NAME = os.getenv('DATABASE_NAME')
+DATABASE_NAME = os.getenv('CA_SERVER_DATABASE_NAME')
 db_state_default = {"closed": None, "conn": None, "ctx": None, "transactions": None}
 db_state = ContextVar("db_state", default=db_state_default.copy())
 


### PR DESCRIPTION
- [x] Add `/health` endpoint to server
- [x] Make all poetry files owned by python user with non-root access
- [x] Make user and cert rout prefixes configurable with environment variables
- [x] Point docker-compose file to Docker Hub image 
- [x] Add environment vars to README
- [x] Add directions for running behind a proxy to README 
- [x] Add LICENSE file 