### PR TITLE
Fix: delete user uses old models

### DIFF
--- a/server/crud.py
+++ b/server/crud.py
@@ -29,7 +29,7 @@ def get_app_user(user: str):
 
 
 def delete_app_user(user:str):
-    n = models.AppUser.delete().where(models.AppUser.user == user).execute()
+    n = models.AppUser.delete().where(models.AppUser.id == user).execute()
     return n
 
 


### PR DESCRIPTION
Fix the issue when deleting a user:

File ".ca-server/server/crud.py", line 34, in delete_app_user
    n = models.AppUser.delete().where(models.AppUser.user == user).execute()
                                      ^^^^^^^^^^^^^^^^^^^
AttributeError: type object 'AppUser' has no attribute 'user'